### PR TITLE
refactor(components): optimize usage of React.memo & miscellaneous

### DIFF
--- a/src/components/UserItem/UserItem.tsx
+++ b/src/components/UserItem/UserItem.tsx
@@ -1,12 +1,15 @@
-import { IUser } from 'components/UsersList/UsersList';
+import React from 'react';
+import { IUser } from 'types/user.interface';
 import { ListItem } from './UserItem.styles';
 
-const UserItem = ({ user }: { user: IUser }) => (
-  <ListItem>
-    <p>{user.id}</p>
-    <p>{user.name}</p>
-    <p>@{user.username}</p>
-  </ListItem>
+const UserItem = React.memo<{ user: IUser }>(
+  ({ user: { id, name, username } }) => (
+    <ListItem>
+      <p>{id}</p>
+      <p>{name}</p>
+      <p>@{username}</p>
+    </ListItem>
+  ),
 );
 
 export default UserItem;

--- a/src/components/UserSearch/UserSearch.tsx
+++ b/src/components/UserSearch/UserSearch.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { SearchWrapper } from './UserSearch.styles';
 
-type UserSearchProps = {
-  readonly setSearchTerm: React.Dispatch<React.SetStateAction<string>>;
+type Props = {
+  setSearchTerm: React.Dispatch<React.SetStateAction<string>>;
 };
 
 // Returning JSX with <label> element for a11y purposes
-const UserSearch = React.memo<UserSearchProps>(({ setSearchTerm }) => (
+const UserSearch = React.memo<Props>(({ setSearchTerm }) => (
   <SearchWrapper>
     <label htmlFor="search">
       Search for user:

--- a/src/components/UsersList/UsersList.tsx
+++ b/src/components/UsersList/UsersList.tsx
@@ -2,21 +2,15 @@ import React, { useEffect, useState } from 'react';
 import { api, endpoints } from 'api';
 import UserItem from 'components/UserItem/UserItem';
 import hasNameFilter from 'utils/hasNameFilter';
+import { IUser } from 'types/user.interface';
 import { List, ListHeading } from './UsersList.styles';
 
 type UsersListProps = {
   readonly searchTerm: string;
 };
 
-export interface IUser {
-  id: number;
-  name: string;
-  username: string;
-  key: number;
-}
-
 const UsersList = React.memo<UsersListProps>(({ searchTerm }) => {
-  const [users, setUsers] = useState([]);
+  const [users, setUsers] = useState<IUser[]>([]);
 
   useEffect(() => {
     api
@@ -36,8 +30,8 @@ const UsersList = React.memo<UsersListProps>(({ searchTerm }) => {
       <List>
         {users.length ? (
           users
-            .filter((user: IUser) => hasNameFilter(user.name, searchTerm))
-            .map((user: IUser) => <UserItem key={user.id} user={user} />)
+            .filter((user) => hasNameFilter(user.name, searchTerm))
+            .map((user) => <UserItem key={user.id} user={user} />)
         ) : (
           <p>Fetching data...</p>
         )}

--- a/src/types/user.interface.ts
+++ b/src/types/user.interface.ts
@@ -1,0 +1,6 @@
+export interface IUser {
+  id: number;
+  name: string;
+  username: string;
+  key: number;
+}

--- a/src/views/App.tsx
+++ b/src/views/App.tsx
@@ -7,15 +7,13 @@ const App = () => {
   const [searchTerm, setSearchTerm] = useState('');
 
   return (
-    <>
-      <Root>
-        <GlobalStyles />
-        <Wrapper>
-          <UserSearch setSearchTerm={setSearchTerm} />
-          <UsersList searchTerm={searchTerm} />
-        </Wrapper>
-      </Root>
-    </>
+    <Root>
+      <GlobalStyles />
+      <Wrapper>
+        <UserSearch setSearchTerm={setSearchTerm} />
+        <UsersList searchTerm={searchTerm} />
+      </Wrapper>
+    </Root>
   );
 };
 


### PR DESCRIPTION
- usage of React.memo for UserItem for optimization reasons
- change props type naming to, from componentProps to Props only
- type state in useState instead of typing state occurences
- extract IUser to types/user.interface.ts